### PR TITLE
Add deployment docs and env configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Configuration de l'application
+SITE_URL=/DaCar
+
+# Paramètres de connexion à la base de données
+DB_HOST=localhost
+DB_PORT=3307
+DB_NAME=terancar
+DB_USER=root
+DB_PASS=

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ Le fichier `.htaccess` gère :
 - La gestion des erreurs
 - La protection des dossiers
 
+## 🚀 Déploiement
+
+Un guide détaillé est disponible dans [`docs/deployment.md`](docs/deployment.md).
+Pour un test rapide en local, copiez le fichier `.env.example` vers `.env` puis exécutez `./start_local.sh`.
+
 ## 🔐 Sécurité
 
 - Protection contre les injections SQL avec PDO

--- a/config/config.php
+++ b/config/config.php
@@ -10,19 +10,21 @@ ini_set('display_errors', 1);
 
 // Configuration de base
 define('SITE_NAME', 'Teran\'Cars');
-define('SITE_URL', '/DaCar');
+// Permet de surcharger l'URL de base via une variable d'environnement
+$baseUrl = getenv('SITE_URL') ?: '/DaCar';
+define('SITE_URL', rtrim($baseUrl, '/'));
 
 // Configuration des chemins
 define('PUBLIC_PATH', ROOT_PATH . '/public');
 define('PAGES_PATH', PUBLIC_PATH . '/pages');
 define('ASSETS_PATH', PUBLIC_PATH . '/assets');
 
-// Configuration de la base de données
-$host = 'localhost';
-$username = 'root';
-$password = '';
-$dbname = 'terancar';
-$port = 3307;
+// Configuration de la base de données (surchargée par les variables d'environnement si présentes)
+$host = getenv('DB_HOST') ?: 'localhost';
+$username = getenv('DB_USER') ?: 'root';
+$password = getenv('DB_PASS') ?: '';
+$dbname = getenv('DB_NAME') ?: 'terancar';
+$port = getenv('DB_PORT') ?: 3307;
 
 // Connexion à la base de données PDO
 try {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,35 @@
+# Guide de déploiement
+
+Ce document explique comment lancer l'application TeranCar en environnement local ou sur un serveur.
+
+## Prérequis
+- PHP 8 et l'extension PDO MySQL
+- MySQL/MariaDB
+- Un serveur web (Apache ou Nginx)
+
+## Configuration
+1. Copier le fichier `.env.example` vers `.env` puis adapter les valeurs si nécessaire :
+   ```bash
+   cp .env.example .env
+   ```
+   Les variables disponibles :
+   - `SITE_URL` : chemin de base de l'application (ex. `/DaCar` ou vide en production)
+   - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` : paramètres de connexion MySQL
+
+2. Vérifier le fichier `config/config.php`. Les paramètres sont désormais récupérés depuis les variables d'environnement avec des valeurs par défaut.
+
+## Lancement en local
+Pour un test rapide sans Apache, exécutez :
+```bash
+./start_local.sh
+```
+Puis ouvrez `http://localhost:8000` dans votre navigateur.
+
+## Déploiement sur un serveur Apache
+1. Copier les fichiers du dépôt sur votre serveur.
+2. Configurer Apache pour que le `DocumentRoot` pointe vers le dossier `public` du projet.
+3. S'assurer que `mod_rewrite` est activé afin que le fichier `.htaccess` gère le routage.
+4. Adapter la valeur `SITE_URL` dans votre fichier `.env` (souvent vide en production).
+5. Redémarrer Apache.
+
+Avec cette configuration, le front‑end et l'API (dossier `api/`) seront disponibles et reliés à la même base de données.

--- a/start_local.sh
+++ b/start_local.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Démarre un serveur PHP local pointant sur le dossier public
+php -S localhost:8000 -t public


### PR DESCRIPTION
## Summary
- introduce environment variable support in `config/config.php`
- add a sample `.env.example` file
- provide `start_local.sh` for a quick local server
- document deployment steps in `docs/deployment.md`
- reference deployment guide in README

## Testing
- `bash -n start_local.sh`
- `php -l config/config.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68403cba5858832aa66b9f05e7c1e9d6

## Summary by Sourcery

Introduce environment variable configuration, deployment documentation, and helper scripts for local and server setup

New Features:
- Support base URL and database credentials via environment variables in config/config.php
- Add .env.example file as a template for environment variables
- Provide start_local.sh script to launch a local PHP server

Documentation:
- Add docs/deployment.md with local and Apache deployment instructions
- Update README to reference deployment guide and .env/start_local.sh usage